### PR TITLE
Automatic Builds and Windows/MacOS support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -38,7 +38,7 @@ jobs:
                 mingw-w64-x86_64-openssl
       - uses: actions/checkout@v2
       - name: Makes Binaries
-        run: make
+        run: make EXTRA_FLAG=-static
       - name: Prepare Artifacts
         run: mkdir artifact && mv psardecrypt artifact/. && mv pspdecrypt artifact/.
       - name: Upload Artifacts

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,68 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-linux:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Make binaries
+      run: make
+    - name: Prepare Artifacts
+      run: mkdir artifact && mv psardecrypt artifact/. && mv pspdecrypt artifact/.
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-binaries
+        path: artifact
+        
+  build-windows:
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+             install: >-
+                base-devel
+                git
+                mingw-w64-x86_64-clang
+                mingw-w64-x86_64-openssl
+      - uses: actions/checkout@v2
+      - name: Makes Binaries
+        run: make
+      - name: Prepare Artifacts
+        run: mkdir artifact && mv psardecrypt artifact/. && mv pspdecrypt artifact/.
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-binaries
+          path: artifact
+        
+  build-macos:
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup OpenSSL
+      run: |
+        cd /usr/local/include 
+        ln -s ../opt/openssl/include/openssl .
+    - name: Make binaries
+      run: |
+        export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
+        make CXX='clang++ -std=c++11'
+    - name: Prepare Artifacts
+      run: mkdir artifact && mv psardecrypt artifact/. && mv pspdecrypt artifact/.
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos-binaries
+        path: artifact

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,17 @@ LIBKIRK_SRCS=$(wildcard libkirk/*.c)
 OBJS_PSP=pspdecrypt.o PrxDecrypter.o $(LIBKIRK_SRCS:%.c=%.o)
 OBJS_PSAR=libLZR.o kl4e.o common.o ipl_decrypt.o pspdecrypt_lib.o PrxDecrypter.o psardecrypt.o PsarDecrypter.o $(LIBKIRK_SRCS:%.c=%.o)
 
+ifdef MACBUILD
+	STATIC_FLAG=
+else
+	STATIC_FLAG=-static
+endif
+
+
 all: $(BIN_PSP) $(BIN_PSAR)
 
 $(BIN_PSP): $(OBJS_PSP)
-	$(CXX) -Bstatic -o $@ $(OBJS_PSP)
+	$(CXX) $(STATIC_FLAG) -o $@ $(OBJS_PSP)
 
 $(BIN_PSAR): $(OBJS_PSAR)
-	$(CXX) -Bstatic -o $@ $(OBJS_PSAR) -lz -lcrypto
+	$(CXX) $(STATIC_FLAG) -o $@ $(OBJS_PSAR) -lz -lcrypto

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OBJS_PSAR=libLZR.o kl4e.o common.o ipl_decrypt.o pspdecrypt_lib.o PrxDecrypter.o
 all: $(BIN_PSP) $(BIN_PSAR)
 
 $(BIN_PSP): $(OBJS_PSP)
-	$(CXX) -o $@ $(OBJS_PSP)
+	$(CXX) -Bstatic -o $@ $(OBJS_PSP)
 
 $(BIN_PSAR): $(OBJS_PSAR)
-	$(CXX) -o $@ $(OBJS_PSAR) -lz -lcrypto
+	$(CXX) -Bstatic -o $@ $(OBJS_PSAR) -lz -lcrypto

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OBJS_PSAR=libLZR.o kl4e.o common.o ipl_decrypt.o pspdecrypt_lib.o PrxDecrypter.o
 all: $(BIN_PSP) $(BIN_PSAR)
 
 $(BIN_PSP): $(OBJS_PSP)
-	clang++ -o $@ $(OBJS_PSP)
+	$(CXX) -o $@ $(OBJS_PSP)
 
 $(BIN_PSAR): $(OBJS_PSAR)
-	clang++ -o $@ $(OBJS_PSAR) -lz -lcrypto
+	$(CXX) -o $@ $(OBJS_PSAR) -lz -lcrypto

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CC=clang
 CXX=clang++
+EXTRA_FLAG=
+
 
 BIN_PSP=pspdecrypt
 BIN_PSAR=psardecrypt
@@ -7,17 +9,10 @@ LIBKIRK_SRCS=$(wildcard libkirk/*.c)
 OBJS_PSP=pspdecrypt.o PrxDecrypter.o $(LIBKIRK_SRCS:%.c=%.o)
 OBJS_PSAR=libLZR.o kl4e.o common.o ipl_decrypt.o pspdecrypt_lib.o PrxDecrypter.o psardecrypt.o PsarDecrypter.o $(LIBKIRK_SRCS:%.c=%.o)
 
-ifdef MACBUILD
-	STATIC_FLAG=
-else
-	STATIC_FLAG=-static
-endif
-
-
 all: $(BIN_PSP) $(BIN_PSAR)
 
 $(BIN_PSP): $(OBJS_PSP)
-	$(CXX) $(STATIC_FLAG) -o $@ $(OBJS_PSP)
+	$(CXX) $(EXTRA_FLAG) -o $@ $(OBJS_PSP)
 
 $(BIN_PSAR): $(OBJS_PSAR)
-	$(CXX) $(STATIC_FLAG) -o $@ $(OBJS_PSAR) -lz -lcrypto
+	$(CXX) $(EXTRA_FLAG) -o $@ $(OBJS_PSAR) -lz -lcrypto

--- a/PsarDecrypter.cpp
+++ b/PsarDecrypter.cpp
@@ -554,6 +554,10 @@ int pspDecryptPSAR(u8 *dataPSAR, u32 size)
         table_mode = 0;
     }
 
+#ifdef _WIN32
+	#define mkdir(a,b) mkdir(a)
+#endif
+
     mkdir("./F0", 0777);
     mkdir("./F0/PSARDUMPER", 0777);
     mkdir("./F0/data", 0777);

--- a/libLZR.c
+++ b/libLZR.c
@@ -12,7 +12,7 @@
  *
  */
 
-#include <malloc.h>
+#include <stdlib.h>
 #include "libLZR.h"
 
 void LZRFillBuffer(unsigned int *test_mask, unsigned int *mask, unsigned int *buffer, unsigned char **next_in) {


### PR DESCRIPTION
Here's the changes made to the code to allow it compile in other OSes:

* Windows
    * `mkdir` with two arguments is deprecated, so a macro was added to swallow the second argument

* MacOS
    * `libLZR.c` was including `malloc.h` which is a deprecated header, it was replaced with `stdlib.h`


For the automatic builds `-static` flag statically links user libraries which makes distribution much easier, specially for the Windows version.