### PR TITLE
Add decompression for ~PSP files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.BIN
 *.dec
 pspdecrypt
+.vscode/
+*.exe

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ CC=clang
 CXX=clang++
 #EXTRA_FLAG= -lprofiler
 EXTRA_FLAG=
-CFLAGS=-O3
-CXXFLAGS=-O3
+CFLAGS=-O3 -Wno-deprecated-declarations
+CXXFLAGS=-O3 -Wno-deprecated-declarations
 
 BIN=pspdecrypt
 LIBKIRK_SRCS=$(wildcard libkirk/*.c)

--- a/PrxDecrypter.h
+++ b/PrxDecrypter.h
@@ -21,9 +21,12 @@
 #include "CommonTypes.h"
 #include "Swap.h"
 
+#define PSP_HEADER_SIZE (0x150)
+
 #ifdef _MSC_VER
 #pragma pack(push, 1)
 #endif
+
 typedef struct
 {
 	u32_le      signature;       // 0

--- a/PsarDecrypter.h
+++ b/PsarDecrypter.h
@@ -21,4 +21,4 @@
 #include "CommonTypes.h"
 #include "Swap.h"
 
-int pspDecryptPSAR(u8 *inbuf, u32 size, std::string outdir, bool extractOnly, u8 *preipl, u32 preiplSize, bool verbose, bool infoOnly, bool keepAll);
+int pspDecryptPSAR(u8 *inbuf, u32 size, std::string outdir, bool extractOnly, u8 *preipl, u32 preiplSize, bool verbose, bool infoOnly, bool keepAll, bool decompPsp = true);

--- a/libkirk/ec.c
+++ b/libkirk/ec.c
@@ -295,8 +295,8 @@ static void generate_ecdsa(u8 *outR, u8 *outS, u8 *k, u8 *hash)
 
   bn_from_mon(R, ec_N, 21);
   bn_from_mon(S, ec_N, 21);
-  memcpy(outR,R+1,0x20);
-  memcpy(outS,S+1,0x20);
+  memcpy(outR,R+1,20);
+  memcpy(outS,S+1,20);
 }
 
     // Signing = 

--- a/pspdecrypt_lib.cpp
+++ b/pspdecrypt_lib.cpp
@@ -322,18 +322,29 @@ int decryptIPL(u8 *inData, u32 inDataSize, int version, const char *filename, st
     return 0;
 }
 
+u32 pspGetTagVal(const u8 *buf)
+{
+    return buf ? (u32)*(u32_le *)&buf[0xD0] : 0;
+}
+
+int pspGetElfSize(const u8 *buf)
+{
+    return buf ? (int)*(u32_le *)&buf[0x28] : 0;
+}
+
+int pspGetCompSize(const u8 *buf)
+{
+    return buf ? (int)*(u32_le *)&buf[0xB0] : 0;
+}
+
 ////////// Decompression //////////
 
-int pspIsCompressed(u8 *buf)
+int pspIsCompressed(const u8 *buf)
 {
-	int res = 0;
-
-	if (buf[0] == 0x1F && buf[1] == 0x8B)
-		res = 1;
-	else if (memcmp(buf, "2RLZ", 4) == 0)
-		res = 1;
-
-	return res;
+	return (buf[0] == 0x1F && buf[1] == 0x8B) || /* GZIP header */
+		   (memcmp(buf, "2RLZ", 4) == 0)      ||
+		   (memcmp(buf, "KL4E", 4) == 0)      ||
+		   (memcmp(buf, "KL3E", 4) == 0);
 }
 
 int pspDecompress(u8 *inbuf, u32 insize, u8 *outbuf, u32 outcapacity, std::string &logStr, u8 **inbufEnd)

--- a/pspdecrypt_lib.h
+++ b/pspdecrypt_lib.h
@@ -67,13 +67,34 @@ int pspDecryptIPL3(const u8* pbIn, u8* pbOut, int cbIn);
 int decryptIPL(u8 *inData, u32 inDataSize, int version, const char *filename, std::string outdir, u8 *preipl, u32 preiplSize, bool verbose, bool keepAll, std::string &logStr);
 
 /**
+ * Get the PSP module tag as an unsigned int.
+ * @param buf Pointer to the ~PSP header buffer (size >= 0x150 bytes)
+ * @return PSP module tag 
+ */
+u32 pspGetTagVal(const u8 *buf);
+
+/**
+ * Get the size of the decrypted & decompressed ELF module.
+ * @param buf Pointer to the ~PSP header buffer (size >= 0x150 bytes)
+ * @return the ELF data size
+ */
+int pspGetElfSize(const u8 *buf);
+
+/**
+ * Get the size of the decrypted module data (possibly compressed).
+ * @param buf Pointer to the ~PSP header buffer (size >= 0x150 bytes)
+ * @return the decrypted data size
+ */
+int pspGetCompSize(const u8 *buf);
+
+/**
  * Checks if buffer is compressed
  *
  * @param buf - The buffer 
  *
  * @returns 1 if compressed, 0 otherwise
 */
-int pspIsCompressed(u8 *buf);
+int pspIsCompressed(const u8 *buf);
 
 /**
  * Decompresses a GZIP or 2RLZ data


### PR DESCRIPTION
This adds a few things:
- Decompress ~PSP files (eg. `OPNSSMP.BIN` which is KL4E-compressed) including `DATA.PSP` within PBP
- Add an option `-c` or `--no-decomp` to explicity not decompress ~PSP files (eg. extracted firmware files)

Along with a few minor changes here and there.