### PR TITLE
Create Apple Silicon build and bump up GH Action version

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -70,8 +70,7 @@ jobs:
     - name: Make binaries
       run: |
         export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
-        export INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
-        brew --prefix openssl
+        export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
         make CXX='clang++ -std=c++11'
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Make binaries
       run: make
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: linux-binaries
         path: artifact
@@ -29,44 +29,28 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@v4
         with:
              install: >-
                 base-devel
                 git
                 mingw-w64-x86_64-clang
                 mingw-w64-x86_64-openssl
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Makes Binaries
         run: make EXTRA_FLAG=-static
       - name: Prepare Artifacts
         run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: windows-binaries
           path: artifact
         
-  build-macos:
-    runs-on: macos-latest
+  build-macos-x86:
+    runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
-    - name: Make binaries
-      run: |
-        export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
-        make CXX='clang++ -std=c++11'
-    - name: Prepare Artifacts
-      run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: macos-binaries
-        path: artifact
-
-  build-macos-arm:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Make binaries
       run: |
         # export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
@@ -74,7 +58,22 @@ jobs:
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: macos-binaries
+        name: macos-intel-binaries
+        path: artifact
+
+  build-macos-arm:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Make binaries
+      run: |
+        make CXX='clang++ -std=c++11'
+    - name: Prepare Artifacts
+      run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: macos-silicon-binary
         path: artifact

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,7 +29,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: msys2/setup-msys2@v4
+      - uses: msys2/setup-msys2@v2
         with:
              install: >-
                 base-devel
@@ -64,7 +64,7 @@ jobs:
         path: artifact
 
   build-macos-arm:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: Make binaries

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -71,6 +71,7 @@ jobs:
       run: |
         export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
         export INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
+        brew --prefix openssl
         make CXX='clang++ -std=c++11'
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -53,7 +53,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Make binaries
       run: |
-        # export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
+        export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
+        export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
         make CXX='clang++ -std=c++11'
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -75,13 +75,13 @@ jobs:
         export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
         make CXX='clang++ -std=c++11 -target arm64-apple-darwin20.1.0 -o pspdecrypt-arm64'
     - name: Download Artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: macos-intel-binaries
         path: artifact
     - name: Make Universal Binary
       run: |
-        unzip macos-intel-binaries.zip
+        unzip artifact/macos-intel-binaries.zip
         lipo pspdecrypt-arm64 pspdecrypt-x86_64 -create -output pspdecrypt
 
     - name: Prepare Artifacts

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -62,3 +62,19 @@ jobs:
       with:
         name: macos-binaries
         path: artifact
+
+  build-macos-arm:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Make binaries
+      run: |
+        # export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
+        make CXX='clang++ -std=c++11'
+    - name: Prepare Artifacts
+      run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos-binaries
+        path: artifact

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
         export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
-        make CXX='clang++ -std=c++11 -target arm64-apple-darwin20.1.0 -o pspdecrypt-arm64'
+        make CXX='clang++ -std=c++11 -target arm64-apple-darwin20.1.0'
     - name: Download Artifact
       uses: actions/download-artifact@v4
       with:
@@ -81,7 +81,7 @@ jobs:
         path: artifact
     - name: Make Universal Binary
       run: |
-        lipo pspdecrypt-arm64 ~/work/pspdecrypt/pspdecrypt/artifact/pspdecrypt -create -output pspdecrypt
+        lipo pspdecrypt ~/work/pspdecrypt/pspdecrypt/artifact/pspdecrypt -create -output pspdecrypt
 
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -73,6 +73,7 @@ jobs:
         export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
         export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
         make CXX='clang++ -std=c++11 -target arm64-apple-darwin20.1.0 -o pspdecrypt-arm64'
+        make clean
         make CXX='clang++ -std=c++11 -target x86_64-apple-darwin-macho -o pspdecrypt-x86_64'
         lipo pspdecrypt-arm64 pspdecrypt-x86_64 -create -output pspdecrypt
     - name: Prepare Artifacts

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -64,7 +64,7 @@ jobs:
         name: macos-intel-binaries
         path: artifact
 
-  build-macos-arm:
+  build-macos-universal:
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
@@ -72,11 +72,13 @@ jobs:
       run: |
         export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
         export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
-        make CXX='clang++ -std=c++11'
+        make CXX='clang++ -std=c++11 -target arm64-apple-darwin20.1.0 -o pspdecrypt-arm64'
+        make CXX='clang++ -std=c++11 -target x86_64-apple-darwin-macho -o pspdecrypt-x86_64'
+        lipo pspdecrypt-arm64 pspdecrypt-x86_64 -o pspdecrypt
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: macos-silicon-binary
+        name: macos-universal-binary
         path: artifact

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -65,6 +65,7 @@ jobs:
         path: artifact
 
   build-macos-universal:
+    needs: build-macos-x86
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -82,6 +82,7 @@ jobs:
     - name: Make Universal Binary
       run: |
         lipo pspdecrypt ~/work/pspdecrypt/pspdecrypt/artifact/pspdecrypt -create -output pspdecrypt
+        rm -rf ~/work/pspdecrypt/pspdecrypt/artifact/
 
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
         export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
-        make CXX='clang++ -std=c++11 -target x86_64-apple-darwin-macho -o pspdecrypt-x86_64'
+        make CXX='clang++ -std=c++11 -target x86_64-apple-darwin-macho'
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
     - name: Upload Artifacts
@@ -81,8 +81,7 @@ jobs:
         path: artifact
     - name: Make Universal Binary
       run: |
-        unzip artifact/macos-intel-binaries.zip
-        lipo pspdecrypt-arm64 pspdecrypt-x86_64 -create -output pspdecrypt
+        lipo pspdecrypt-arm64 ~/work/pspdecrypt/pspdecrypt/artifact/pspdecrypt -create -output pspdecrypt
 
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -69,6 +69,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Make binaries
       run: |
+        export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
+        export INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
         make CXX='clang++ -std=c++11'
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
         export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
-        make CXX='clang++ -std=c++11'
+        make CXX='clang++ -std=c++11 -target x86_64-apple-darwin-macho -o pspdecrypt-x86_64'
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
     - name: Upload Artifacts
@@ -73,9 +73,16 @@ jobs:
         export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix openssl)/lib
         export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
         make CXX='clang++ -std=c++11 -target arm64-apple-darwin20.1.0 -o pspdecrypt-arm64'
-        make clean
-        make CXX='clang++ -std=c++11 -target x86_64-apple-darwin-macho -o pspdecrypt-x86_64'
+    - name: Download Artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: macos-intel-binaries
+        path: artifact
+    - name: Make Universal Binary
+      run: |
+        unzip macos-intel-binaries.zip
         lipo pspdecrypt-arm64 pspdecrypt-x86_64 -create -output pspdecrypt
+
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
     - name: Upload Artifacts

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -74,7 +74,7 @@ jobs:
         export CPLUS_INCLUDE_PATH=$INCLUDE_PATH:$(brew --prefix openssl)/include
         make CXX='clang++ -std=c++11 -target arm64-apple-darwin20.1.0 -o pspdecrypt-arm64'
         make CXX='clang++ -std=c++11 -target x86_64-apple-darwin-macho -o pspdecrypt-x86_64'
-        lipo pspdecrypt-arm64 pspdecrypt-x86_64 -o pspdecrypt
+        lipo pspdecrypt-arm64 pspdecrypt-x86_64 -create -output pspdecrypt
     - name: Prepare Artifacts
       run: mkdir artifact && mv pspdecrypt artifact/. && cp Readme.md artifact/.
     - name: Upload Artifacts


### PR DESCRIPTION
This adds an additional binary for Apple Silicon which uses the  macos-14 runner, although github specifies that macos-latest is the one to use, I cannot seem to get it to give us a Silicon binary so here we are.

The existing intel version has been moved down to macos-12

Note for folks that use this you will need to run **xattr -rd com.apple.quarantine pspdecrypt**  or right click and "open" the binary before it will work in later macOS Releases.


