### PR TITLE
Add missing prototype

### DIFF
--- a/libkirk/SHA1.c
+++ b/libkirk/SHA1.c
@@ -138,9 +138,8 @@ void SHAInit(SHA_CTX *shsInfo)
 
    Note that this corrupts the shsInfo->data area */
 
-static void SHSTransform( digest, data )
-     UINT4 *digest, *data ;
-    {
+static void SHSTransform(UINT4 *digest, UINT4 *data)
+{
     UINT4 A, B, C, D, E;     /* Local vars */
     UINT4 eData[ 16 ];       /* Expanded data */
 

--- a/libkirk/SHA1.h
+++ b/libkirk/SHA1.h
@@ -39,6 +39,7 @@ typedef struct
 void SHAInit(SHA_CTX *);
 void SHAUpdate(SHA_CTX *, BYTE *buffer, int count);
 void SHAFinal(BYTE *output, SHA_CTX *);
+static void SHSTransform(UINT4 *digest, UINT4 *data);
 
 #endif /* end _SHA_H_ */
 


### PR DESCRIPTION
Fix the following warning on `libkirk/SHA1.c`.

```sh
clang -03 -c -o libkirk/SHA1.o libkirk/SHA1.c
libkirk/SHA1.c:141:13: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C23 [-Wdeprecated-non-prototype]
```
